### PR TITLE
230613_Eunji_feat: 메인페이지 Header, SignIn, SignUp, SignOut 추가

### DIFF
--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const MainHeader = styled.nav`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+const Title = styled.h1`
+  font-size: 3rem;
+`;
+
+const Header = () => {
+  const navigate = useNavigate(); //페이지 이동
+  const accessToken = localStorage.getItem('token'); // localStorage에서 accessToken 가져오기
+
+  async function handleSignIn() {
+    navigate(`/signin`);
+  }
+
+  async function handleLogout() {
+    localStorage.removeItem('token'); // localStorage에서 accessToken 제거
+    navigate(`/`);
+  }
+
+  async function handleMyPage() {
+    navigate(`/`);
+  }
+
+  return (
+    <>
+      <MainHeader>
+        <Title>OP-AL</Title>
+        <div>
+          {accessToken ? (
+            <>
+              <button onClick={handleLogout}>로그아웃</button>
+              <button onClick={handleMyPage}>마이페이지</button>
+            </>
+          ) : (
+            <>
+              <button onClick={handleSignIn}>로그인</button>
+            </>
+          )}
+        </div>
+      </MainHeader>
+    </>
+  );
+};
+
+export default Header;

--- a/src/Pages/Home/Home.tsx
+++ b/src/Pages/Home/Home.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
-
-const Title = styled.h1`
-  font-size: 3rem;
-`;
+import Header from 'Components/Header/Header';
 
 const Home = () => {
-  return <Title>OP-AL 프로젝트 임시 Home페이지 입니다.</Title>;
+  return (
+    <>
+      <Header />
+    </>
+  );
 };
 
 export default Home;

--- a/src/Pages/Routes.tsx
+++ b/src/Pages/Routes.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import Home from './Home/Home';
+import SignUp from './SignUp/SignUp';
+import SignIn from './SignIn/SignIn';
 
 const RoutesComponent = () => {
   return (
     <Routes>
       <Route path="/*" element={<Home />} />
+      <Route path="/signup" element={<SignUp />} />
+      <Route path="/signin" element={<SignIn />} />
     </Routes>
   );
 };

--- a/src/Pages/SignIn/SignIn.tsx
+++ b/src/Pages/SignIn/SignIn.tsx
@@ -1,12 +1,75 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useState, FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Header from 'Components/Header/Header';
 
-const Title = styled.h1`
-  font-size: 3rem;
-`;
+interface RequestBody {
+  email: string; // 사용자 아이디 (필수!)
+  password: string; // 사용자 비밀번호 (필수!)
+}
 
 const SignIn = () => {
-  return <Title>OP-AL 프로젝트 임시 SignIn 페이지 입니다.</Title>;
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate(); //페이지 이동
+
+  async function handleSignUp() {
+    navigate(`/signup`);
+  }
+
+  const headers = {
+    'content-type': 'application/json',
+    apikey: 'KDT5_nREmPe9B',
+    username: 'KDT5_Team3',
+  };
+
+  async function handleSignIn(event: FormEvent) {
+    event.preventDefault();
+    const requestBody: RequestBody = { email, password };
+    const res = await fetch(
+      'https://asia-northeast3-heropy-api.cloudfunctions.net/api/auth/login',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(requestBody),
+      }
+    );
+    const json = await res.json();
+    console.log(json);
+    if (res.ok) {
+      localStorage.setItem('token', json.accessToken);
+      navigate(`/`);
+    } else {
+      setMessage(
+        '로그인에 실패하였습니다. 이메일과 비밀번호를 다시 확인해주세요'
+      );
+    }
+  }
+
+  return (
+    <div>
+      <Header />
+      <h1>로그인</h1>
+      <form onSubmit={handleSignIn}>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          type="text"
+          placeholder="email"
+        />
+        <input
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          type="password"
+          placeholder="password"
+        />
+        <button type="submit">로그인</button>
+      </form>
+      <button>아이디/비밀번호 찾기</button>
+      <button onClick={handleSignUp}>회원 가입</button>
+      {message && <h3>{message}</h3>}
+    </div>
+  );
 };
 
 export default SignIn;

--- a/src/Pages/SignUp/SignUp.tsx
+++ b/src/Pages/SignUp/SignUp.tsx
@@ -1,12 +1,137 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useState, FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Header from 'Components/Header/Header';
+interface RequestBody {
+  email: string; // 사용자 아이디 (필수!)
+  password: string; // 사용자 비밀번호, 8자 이상 (필수!)
+  passwordCheck: string; // 비밀번호 확인 값 추가
+  displayName: string; // 사용자 이름, 20자 이하 (필수!)
+  profileImgBase64?: string; // 사용자 프로필 이미지(base64) - jpg, jpeg, webp, png, gif, svg
+}
 
-const Title = styled.h1`
-  font-size: 3rem;
-`;
+interface ResponseData {
+  accessToken: string; // 액세스 토큰
+}
 
 const SignUp = () => {
-  return <Title>OP-AL 프로젝트 임시 SignUp 페이지 입니다.</Title>;
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordCheck, setPasswordCheck] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate(); //페이지 이동
+
+  async function handleSignIn() {
+    navigate(`/signin`);
+  }
+
+  const headers = {
+    'content-type': 'application/json',
+    apikey: 'KDT5_nREmPe9B',
+    username: 'KDT5_Team3',
+  };
+
+  //회원가입
+  async function handleSignUp(event: FormEvent) {
+    event.preventDefault();
+
+    //비밀번호 확인
+    if (password !== passwordCheck) {
+      setMessage('비밀번호를 확인해주세요.');
+      return;
+    }
+
+    const requestBody: RequestBody = {
+      email,
+      password,
+      passwordCheck,
+      displayName,
+    };
+    const res = await fetch(
+      'https://asia-northeast3-heropy-api.cloudfunctions.net/api/auth/signup',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(requestBody),
+      }
+    );
+    const json = await res.json();
+    console.log(json);
+    if (res.ok) {
+      authenticate(json.accessToken);
+    } else {
+      setMessage(
+        '회원가입에 실패하였습니다. 이메일과 비밀번호를 다시 확인해주세요.'
+      );
+    }
+  }
+
+  //인증
+  async function authenticate(accessToken: string) {
+    try {
+      const res = await fetch(
+        'https://asia-northeast3-heropy-api.cloudfunctions.net/api/auth/me',
+        {
+          method: 'POST',
+          headers: {
+            ...headers,
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+      const json: ResponseData = await res.json();
+      console.log(json);
+      setMessage('회원가입이 완료되었습니다.');
+    } catch (error) {
+      console.error(error);
+      setMessage('인증에 실패하였습니다');
+    }
+  }
+
+  return (
+    <div>
+      <Header />
+      <h1>회원가입</h1>
+      <form onSubmit={handleSignUp}>
+        <input
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          type="text"
+          placeholder="UserName"
+        />
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          type="text"
+          placeholder="아이디(email)"
+        />
+        <input
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          type="password"
+          placeholder="비밀번호"
+        />
+        <input
+          value={passwordCheck}
+          onChange={(e) => {
+            setPasswordCheck(e.target.value);
+          }}
+          type="password"
+          placeholder="비밀번호 확인"
+        />
+        <button type="submit">회원가입하기</button>
+      </form>
+
+      {message && (
+        <>
+          <h3>{message}</h3>
+          {message !== '비밀번호를 확인해주세요.' && (
+            <button onClick={handleSignIn}>로그인하기</button>
+          )}
+        </>
+      )}
+    </div>
+  );
 };
 
 export default SignUp;


### PR DESCRIPTION
**[파일 추가]**
/src/Components/Header/Header.tsx

**[파일 수정]**
/src/Pages/Routes.tsx
/src/Pages/SignUp/SignUp.tsx
/src/Pages/SignIn/SignIn.tsx
/src/Pages/Home/Home.tsx

**[추가 내용]**
1. 메인페이지, 로그인페이지, 회원가입 페이지에 모두 Header 컴포넌트 공통 적용
2. 회원가입 시 비밀번호 확인까지 2번 작성하도록 추가
3. 로그인 시 accessToken을 localStorage에 저장
     - accessToken이 localStorage에 존재하면 로그인한 상태이므로 로그아웃 버튼이 표시됨
     - accessToken이 localStorage에 존재하지 않으면 로그인 전 상태